### PR TITLE
FIX3P-5 Annotation Blurring After Return

### DIFF
--- a/src/assets/js/stage/annotation.ts
+++ b/src/assets/js/stage/annotation.ts
@@ -80,6 +80,13 @@ export default class Annotation extends HTMLElement {
             colorSwitcher.value = this.color;
         }
 
+        this.onkeydown = e => {
+            if(e.key === "Enter") {
+                e.preventDefault();
+                this.blur();
+            }
+        }
+
         this.onkeyup = () => {
             let value = sanitize(this.value);
             let annotations = Session.x3p.mask.annotations;


### PR DESCRIPTION
Don't allow newlines in annotations - blurs the annotation after pressing enter instead