### PR TITLE
FIX3P-14 Change Krash URL

### DIFF
--- a/src/assets/js/logger/reporter/krash-reporter.ts
+++ b/src/assets/js/logger/reporter/krash-reporter.ts
@@ -2,7 +2,8 @@ import { LogReporter, LogReporterResponse, LogReporterOptions } from ".";
 import Item from "../item";
 import axios from "axios";
 
-const KRASH_REPORT_URL = "https://krash.vila.cythral.com/report";
+const KRASH_REPORT_URL = "https://krash.brigh.id/report";
+
 export default class KrashReporter implements LogReporter {
     private version: string;
 


### PR DESCRIPTION
Updates the Krash URL / report endpoint to the AWS hosted one (the vila server on vultr is now EOL)