### PR TITLE
FIX3P-18 Paint Mode: Show Annotation Colors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2081,9 +2081,9 @@
       }
     },
     "blueimp-md5": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.12.0.tgz",
-      "integrity": "sha512-zo+HIdIhzojv6F1siQPqPFROyVy7C50KzHv/k/Iz+BtvtVzSHXiMXOpq2wCfNkeBqdCv+V8XOV96tsEt2W/3rQ=="
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.13.0.tgz",
+      "integrity": "sha512-lmp0m647R5e77ORduxLW5mISIDcvgJZa52vMBv5uVI3UmSWTQjkJsZVBfaFqQPw/QFogJwvY6e3Gl9nP+Loe+Q=="
     },
     "bn.js": {
       "version": "4.11.8",
@@ -3899,54 +3899,6 @@
         "cwise-parser": "^1.0.0",
         "static-module": "^1.0.0",
         "uglify-js": "^2.6.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
-        },
-        "cliui": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-          "requires": {
-            "center-align": "^0.1.1",
-            "right-align": "^0.1.1",
-            "wordwrap": "0.0.2"
-          }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-        },
-        "uglify-js": {
-          "version": "2.8.29",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-          "requires": {
-            "source-map": "~0.5.1",
-            "uglify-to-browserify": "~1.0.0",
-            "yargs": "~3.10.0"
-          }
-        },
-        "wordwrap": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
-        },
-        "yargs": {
-          "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-          "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-          "requires": {
-            "camelcase": "^1.0.2",
-            "cliui": "^2.1.0",
-            "decamelize": "^1.0.0",
-            "window-size": "0.1.0"
-          }
-        }
       }
     },
     "cwise-compiler": {
@@ -5706,14 +5658,14 @@
       }
     },
     "gl-select-static": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/gl-select-static/-/gl-select-static-2.0.4.tgz",
-      "integrity": "sha512-4Kqx5VjeT8nmV+j6fry3UBFNL2B7ktQU4o508QGVPKWCILlV44rTDq3mnBFThup8rMIH9kJQx6xWsg9jTmfeMw==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/gl-select-static/-/gl-select-static-2.0.6.tgz",
+      "integrity": "sha512-p4DmBG1DMo/47/fV3oqPcU6uTqHy0eI1vATH1fm8OVDqlzWnLv3786tdEunZWG6Br7DUdH6NgWhuy4gAlt+TAQ==",
       "requires": {
         "bit-twiddle": "^1.0.2",
-        "cwise": "^1.0.3",
-        "gl-fbo": "^2.0.3",
-        "ndarray": "^1.0.15",
+        "cwise": "^1.0.10",
+        "gl-fbo": "^2.0.5",
+        "ndarray": "^1.0.18",
         "typedarray-pool": "^1.1.0"
       }
     },
@@ -7803,9 +7755,9 @@
       }
     },
     "jszip": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.2.2.tgz",
-      "integrity": "sha512-NmKajvAFQpbg3taXQXr/ccS2wcucR1AZ+NtyWp2Nq7HHVsXhcJFR8p0Baf32C2yVvBylFWVeKf+WI2AnvlPhpA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.4.0.tgz",
+      "integrity": "sha512-gZAOYuPl4EhPTXT0GjhI3o+ZAz3su6EhLrKUoAivcKqyqC7laS5JEv4XWZND9BgcDcF83vI85yGbDmDR6UhrIg==",
       "requires": {
         "lie": "~3.3.0",
         "pako": "~1.0.2",
@@ -8390,9 +8342,9 @@
       "dev": true
     },
     "ndarray": {
-      "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/ndarray/-/ndarray-1.0.18.tgz",
-      "integrity": "sha1-tg06cyJOxVXQ+qeXEeUCRI/T95M=",
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/ndarray/-/ndarray-1.0.19.tgz",
+      "integrity": "sha512-B4JHA4vdyZU30ELBw3g7/p9bZupyew5a7tX1Y/gGeF2hafrPaQZhgrGQfsvgfYbgdFZjYwuEcnaobeM/WMW+HQ==",
       "requires": {
         "iota-array": "^1.0.0",
         "is-buffer": "^1.0.2"
@@ -11958,9 +11910,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typedarray-pool": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/typedarray-pool/-/typedarray-pool-1.1.0.tgz",
-      "integrity": "sha1-0RT0hIAUifU+yrXoCIqiMET0mNk=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/typedarray-pool/-/typedarray-pool-1.2.0.tgz",
+      "integrity": "sha512-YTSQbzX43yvtpfRtIDAYygoYtgT+Rpjuxy9iOpczrjpXLgGoyG7aS5USJXV2d3nn8uHTeb9rXDvzS27zUg5KYQ==",
       "requires": {
         "bit-twiddle": "^1.0.0",
         "dup": "^1.0.0"
@@ -11971,6 +11923,54 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
       "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
       "dev": true
+    },
+    "uglify-js": {
+      "version": "2.8.29",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+      "requires": {
+        "source-map": "~0.5.1",
+        "uglify-to-browserify": "~1.0.0",
+        "yargs": "~3.10.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
+        },
+        "cliui": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+          "requires": {
+            "center-align": "^0.1.1",
+            "right-align": "^0.1.1",
+            "wordwrap": "0.0.2"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        },
+        "wordwrap": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
+        },
+        "yargs": {
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+          "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+          "requires": {
+            "camelcase": "^1.0.2",
+            "cliui": "^2.1.0",
+            "decamelize": "^1.0.0",
+            "window-size": "0.1.0"
+          }
+        }
+      }
     },
     "uglify-to-browserify": {
       "version": "1.0.2",
@@ -12583,9 +12583,9 @@
       }
     },
     "x3p.js": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/x3p.js/-/x3p.js-0.10.1.tgz",
-      "integrity": "sha512-sVePo7783+H+PDnkNBjO5xjOn449U9EVX88i6wtF7F1PQuIPYTkKVq97pSVvRoTSZa8Yp4dyorqFrVg0Nf4oGw==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/x3p.js/-/x3p.js-0.10.2.tgz",
+      "integrity": "sha512-pjJyG3TrdtPCdZyJZIUeS5qd5PgGopJdQY/ke+uAWEtGOThkfmYp+OwMnpJC2PNyLLRiw0S0B/wSRmFALP6mFQ==",
       "requires": {
         "@talenfisher/canvas": "^0.3.2",
         "@talenfisher/color": "^0.1.6",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@webcomponents/webcomponentsjs": "^2.4.3",
     "axios": "^0.18.1",
     "fullscreen-api-polyfill": "^1.1.2",
-    "x3p.js": "^0.10.1"
+    "x3p.js": "^0.10.2"
   },
   "devDependencies": {
     "@babel/polyfill": "^7.8.7",

--- a/src/assets/js/index.ts
+++ b/src/assets/js/index.ts
@@ -19,6 +19,7 @@ import "./panorama";
 import "./uploader";
 import "./editor";
 import "./stage";
+import Uploader from "./uploader";
 
 class FiX3P {
     public session = Session;
@@ -59,7 +60,7 @@ class FiX3P {
             popup.display();
             
             let file = await this.readLocalFile(filename);
-            let uploader = document.querySelector("fix3p-uploader");
+            let uploader = document.querySelector("fix3p-uploader") as Uploader;
             
             popup.hide(true);
             uploader.read(file);

--- a/src/assets/js/stage/index.ts
+++ b/src/assets/js/stage/index.ts
@@ -14,6 +14,9 @@ import { throws, CustomElement } from "../decorators";
 import Logger from "../logger";
 import fix3p from "../";
 import Annotations from "./annotations";
+import Color from "@talenfisher/color";
+import { doesNotReject } from "assert";
+import { getX3pAnnotationColors } from "../util";
 
 export interface StageOptions {
     el: HTMLElement;
@@ -99,18 +102,13 @@ export default class Stage extends HTMLElement {
         let mask = Session.x3p.mask;
         mask.on("loaded", () => {
             let texture = mask.getTexture(undefined);
-            let colors = mask.colors;
-            let background = mask.color;
+            let colors = getX3pAnnotationColors(x3p);
             
             texture.setPixels(mask.canvas.el);
             Session.renderer.drawMesh();
 
-            for(let color of colors) {
-                let hex = color.hex6;
-                
-                if(hex !== background) {
-                    this.annotations.set(hex, mask.annotations[hex] || "");
-                }
+            for(let color of colors) {                
+                this.annotations.set(color, mask.annotations[color] || "");
             }
 
             this.ready = true;

--- a/src/assets/js/util.ts
+++ b/src/assets/js/util.ts
@@ -2,6 +2,9 @@
  * Miscellaneous utilities
  */
 
+import X3P from "x3p.js";
+import Color from "@talenfisher/color";
+
 /**
  * Get a value from a header with several parts
  * ie Content-Disposition: attachment; filename="test.jpg"
@@ -26,4 +29,17 @@ export function getHeaderPart(header: string, partname: string) {
     }
 
     return null;
+}
+
+/**
+ * Gets colors to show as annotations for an X3P in paint mode
+ */
+export function getX3pAnnotationColors(x3p: X3P): string[] {
+    const mask = x3p.mask;
+    const annotationColors = Object.keys(mask.annotations).map(hex => new Color(hex));
+    const colors = new Set<string>();
+    for(let color of [...annotationColors, ...mask.colors]) {
+        colors.add(color.hex6);
+    }
+    return [...colors.values()].filter((color) => color !== mask.color);
 }

--- a/tests/unit/util.test.ts
+++ b/tests/unit/util.test.ts
@@ -1,4 +1,6 @@
-import { getHeaderPart } from "../../src/assets/js/util";
+import { getHeaderPart, getX3pAnnotationColors } from "../../src/assets/js/util";
+import Color from "@talenfisher/color";
+import X3P from "x3p.js";
 
 describe("util", () => {
     describe("getHeaderPart", () => {
@@ -12,6 +14,29 @@ describe("util", () => {
             let header = 'attachment; filename="test.jpg"';
             let name = getHeaderPart(header, "name");
             expect(name).toBeNull();
+        });
+    });
+
+    describe("getX3pAnnotationColors", () => {
+        it("Should return an array of colors including annotation colors and read colors", () => {
+            const annotations = { ["#ff0000"]: 'red value', ["#0000ff"]: 'blue value' };
+            const colors = [ new Color("#00ff00") ];
+            const mask = { annotations, colors };
+            const x3p = { mask } as any;
+
+            const actual = getX3pAnnotationColors(x3p);
+            expect(actual).toEqual(["#ff0000", "#0000ff", "#00ff00"]);
+        });
+        
+        it("Should exclude the background color", () => {
+            const annotations = { ["#ff0000"]: 'red value', ["#0000ff"]: 'blue value' };
+            const colors = [ new Color("#00ff00") ];
+            const background = "#ff0000";
+            const mask = { annotations, colors, color: background };
+            const x3p = { mask } as any;
+
+            const actual = getX3pAnnotationColors(x3p);
+            expect(actual).toEqual(["#0000ff", "#00ff00"]);
         });
     });
 });


### PR DESCRIPTION
Fixes #50 

Shows all annotation colors in paint mode, not just the ones that are present on the mask image. 